### PR TITLE
Change header to default_headers in completions function

### DIFF
--- a/src/openai/client.cr
+++ b/src/openai/client.cr
@@ -69,7 +69,7 @@ module OpenAI
         "frequency_penalty" => frequency_penalty,
       }.compact
 
-      event_source = EventSource.new("https://api.openai.com/v1/engines/#{engine}/completions", base_headers: headers, body: body.to_json)
+      event_source = EventSource.new("https://api.openai.com/v1/engines/#{engine}/completions", base_headers: default_headers, body: body.to_json)
 
       event_source.on_message do |message|
         message.data.each do |datum|


### PR DESCRIPTION
I'm getting an error that `headers` is undefined 

```
In lib/openai/src/openai/client.cr:72:111

 72 | event_source = EventSource.new("https://api.openai.com/v1/engines/#{engine}/completions", base_headers: headers, body: body.to_json)
                                                                         
Error: undefined local variable or method 'headers' for OpenAI::Client
```

I believe `headers` should be changed to `default_headers` 

```
private def default_headers
      @headers ||= HTTP::Headers{
        "Authorization" => "Bearer #{@api_key}",
        "Content-Type"  => "application/json",
      }
    end
```